### PR TITLE
Fix #106: The "is installed" test is unreliable

### DIFF
--- a/UPLOAD/inc/plugins/mybbfancybox.php
+++ b/UPLOAD/inc/plugins/mybbfancybox.php
@@ -74,7 +74,7 @@ function mybbfancybox_is_installed()
 {
 	global $db;
 
-	$query = $db->simple_select('themestylesheets', 'sid', "name='mybbfancybox.css'");
+	$query = $db->simple_select('settinggroups', 'gid', "name='mybbfancybox'");
 	return ($db->num_rows($query) > 0);
 }
 


### PR DESCRIPTION
Check for the existence of the plugin's settings group rather than its stylesheet. This is reliable because the plugin's settings are not mistakenly deleted by the bug noted in #106 as the Master stylesheet is.

Resolves #106